### PR TITLE
Ensure the deadlineTimestamp always has a decimal component

### DIFF
--- a/src/ChromeDevtoolsProtocol/Context.php
+++ b/src/ChromeDevtoolsProtocol/Context.php
@@ -37,7 +37,7 @@ class Context implements ContextInterface
 
 	public static function withTimeout(ContextInterface $parent, int $seconds, int $microseconds = 0): ContextInterface
 	{
-		$deadlineTimestamp = microtime(true) + $seconds + ($microseconds / 1000000);
+		$deadlineTimestamp = number_format(microtime(true) + $seconds + ($microseconds / 1000000), 6, '.', '');
 		return static::withDeadline($parent, \DateTimeImmutable::createFromFormat("U.u", $deadlineTimestamp));
 	}
 


### PR DESCRIPTION
$deadlineTimestamp being an exact second results in:
TypeError: Argument 2 passed to ChromeDevtoolsProtocol\Context::withDeadline() must be an instance of DateTimeImmutable, boolean given, called in vendor/jakubkulhan/chrome-devtools-protocol/src/ChromeDevtoolsProtocol/Context.php on line 41