### PR TITLE
Add Launcher::setExecutable() to manually set executable path.

### DIFF
--- a/src/ChromeDevtoolsProtocol/Instance/Launcher.php
+++ b/src/ChromeDevtoolsProtocol/Instance/Launcher.php
@@ -23,6 +23,9 @@ class Launcher
 		"--headless",
 	];
 
+	/** @var string */
+	private $executable;
+
 	/** @var int */
 	private $port;
 
@@ -46,6 +49,18 @@ class Launcher
 		}
 
 		$this->port = $port;
+	}
+
+	/**
+	 * Set remote debugging port.
+	 *
+	 * @param string $executable
+	 * @return self
+	 */
+	public function setExecutable(string $executable)
+	{
+		$this->executable = $executable;
+		return $this;
 	}
 
 	/**
@@ -106,7 +121,10 @@ class Launcher
 	 */
 	public function launch(ContextInterface $ctx, ...$args): ProcessInstance
 	{
-		if (PHP_OS === "Linux") {
+		if ($this->executable) {
+			$executable = $this->executable;
+
+		} else if (PHP_OS === "Linux") {
 			$finder = new ExecutableFinder();
 			$executable = $finder->find(static::DEFAULT_LINUX_EXECUTABLE);
 			if ($executable === null) {

--- a/src/ChromeDevtoolsProtocol/Instance/Launcher.php
+++ b/src/ChromeDevtoolsProtocol/Instance/Launcher.php
@@ -52,7 +52,7 @@ class Launcher
 	}
 
 	/**
-	 * Set remote debugging port.
+	 * Set full path to executable.
 	 *
 	 * @param string $executable
 	 * @return self


### PR DESCRIPTION
Add a method to `Launcher` to manually set the executable, skipping automatic detection.

Solves #6 and part of #3.