### PR TITLE
Change IP address to hostname.

### DIFF
--- a/src/ChromeDevtoolsProtocol/Instance/ProcessInstance.php
+++ b/src/ChromeDevtoolsProtocol/Instance/ProcessInstance.php
@@ -30,7 +30,7 @@ class ProcessInstance implements InstanceInterface, CloseableResourceInterface
 	{
 		$this->process = $process;
 		$this->temporaryUserDataDir = $temporaryUserDataDir;
-		$this->wrappedInstance = new Instance("127.0.0.1", $port);
+		$this->wrappedInstance = new Instance("localhost", $port);
 	}
 
 	public function __destruct()


### PR DESCRIPTION
Some users - including me 😉 - have problems connecting with an IP address, but have no problems using `localhost` (i.e. https://stackoverflow.com/questions/6827310/chrome-remote-debugging-doesnt-work-with-ip)