### PR TITLE
Upgrade guzzle in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "minimum-stability": "stable",
   "require": {
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^7.0",
     "php": "~7.1",
     "symfony/filesystem": ">=2.3",
     "symfony/process": ">=3.3",


### PR DESCRIPTION
Laravel 8 requires guzzle to be set at `^7.0.1`. `chrome-devtools-protocol` sets guzzle at `6.3`. Upon testing it thoroughly there appears to be no impact upgrading guzzle to `^7.0`. 