### PR TITLE
GH-27: Allow the package to be used with guzzlehttp/guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "minimum-stability": "stable",
   "require": {
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.3|^7.0",
     "php": "~7.1",
     "symfony/filesystem": ">=2.3",
     "symfony/process": ">=3.3",


### PR DESCRIPTION
In order to increase compatibility with other packages, updated the
composer requirements to allow consumers to use either Guzzle 6 or 7.