### PR TITLE
Fix/php8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,52 @@ jobs:
     - store_test_results:
         path: /tmp/phpunit
 
+test_8_0:
+    docker:
+    - image: circleci/php:8.0-node-browsers
+    steps:
+    - checkout
+    - run: sudo docker-php-ext-install sockets
+    - restore_cache:
+        keys:
+        - v3_composer_{{ .Branch }}
+    - run:
+        command: |
+          composer update --prefer-dist --no-progress --classmap-authoritative
+    - save_cache:
+        key: v3_composer_{{ .Branch }}
+        paths:
+        - ~/.composer/cache
+    - run:
+        command: |
+          mkdir -p /tmp/phpunit
+          PHPUNIT_FLAGS="--log-junit /tmp/phpunit/junit.xml" make -e test
+    - store_test_results:
+        path: /tmp/phpunit
+
+  test_8_0_lowest:
+    docker:
+    - image: circleci/php:8.0-node-browsers
+    steps:
+    - checkout
+    - run: sudo docker-php-ext-install sockets
+    - restore_cache:
+        keys:
+        - v3_composer_lowest_{{ .Branch }}
+    - run:
+        command: |
+          composer update --prefer-dist --no-progress --classmap-authoritative --prefer-lowest
+    - save_cache:
+        key: v3_composer_lowest_{{ .Branch }}
+        paths:
+        - ~/.composer/cache
+    - run:
+        command: |
+          mkdir -p /tmp/phpunit
+          PHPUNIT_FLAGS="--log-junit /tmp/phpunit/junit.xml" make -e lint phpunit
+    - store_test_results:
+        path: /tmp/phpunit
+
   check_protocol:
     docker:
     - image: circleci/php:7.3-node-browsers
@@ -205,6 +251,8 @@ workflows:
     - test_7_3_lowest
     - test_7_4
     - test_7_4_lowest
+    - test_8_0
+    - test_8_0_lowest
     - check_protocol
 
   nightly:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "minimum-stability": "stable",
   "require": {
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^7.0",
     "php": ">=7.1",
     "symfony/filesystem": ">=2.3",
     "symfony/process": ">=3.3",

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
   "require": {
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3",
-    "php": "~7.1",
+    "php": ">=7.1",
     "symfony/filesystem": ">=2.3",
     "symfony/process": ">=3.3",
     "wrench/wrench": "~2.0.10"
   },
   "require-dev": {
-    "jakub-onderka/php-parallel-lint": "~1.0.0",
+    "php-parallel-lint/php-parallel-lint": "^1.2",
     "nette/php-generator": "~2.1|~3.0",
-    "phpstan/phpstan": "^0.11.4",
-    "phpunit/phpunit": "~6.4"
+    "phpstan/phpstan": "^0.12.82",
+    "phpunit/phpunit": "~6.4|^9.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
+  checkMissingIterableValueType: false
   excludes_analyse:
   # Probably some messed-up imports in PHPStan 0.9, reports errors such as:
   # Method ChromeDevtoolsProtocol\Session::accessibility() should return ChromeDevtoolsProtocol\Domain\AccessibilityDomainInterface but returns object.


### PR DESCRIPTION
Primary changes:
* Set php >=7.1 to allow for php 8.0
* Crossgrade to php-parallel-lint/php-parallel-lint
* Upgrade phpstan
* Enable phpunit v9

Notes:
* phpunit and lint are passing
* phpstan has a lot of primarily "no return typehint specified," "no typehint specified," etc. errors

Do you want to ignore some of these static analysis errors?