### PR TITLE
No deprecations (support php 8.1)

### DIFF
--- a/generate.php
+++ b/generate.php
@@ -446,6 +446,7 @@ class Generator
 		$fromJson->addComment("@param object \$rawData");
 
 		$jsonSerialize = $objectClass->addMethod("jsonSerialize");
+		$jsonSerialize->addAttribute("ReturnTypeWillChange");
 		$jsonSerialize->addBody("return \$this->rawData;");
 
 		$objectClass->addMethod("getRawData")
@@ -521,6 +522,7 @@ class Generator
 		$fromJson->addComment("@return static");
 
 		$jsonSerialize = $objectClass->addMethod("jsonSerialize");
+		$jsonSerialize->addAttribute("ReturnTypeWillChange");
 		$jsonSerialize->addBody("\$data = new \\stdClass();");
 
 		$builderClass = null;


### PR DESCRIPTION
This removes PHP 8.1 deprecations for jsonSerialize return type.

e.g.
```
PHP Deprecated:  Return type of ChromeDevtoolsProtocol\Model\Page\NavigateRequest::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /projet/vendor/jakubkulhan/chrome-devtools-protocol/gen-src/ChromeDevtoolsProtocol/Model/Page/NavigateRequest.php on line 76
```
This adds attribute ReturnTypeWillChange which is a recommendation for projects needing backwards compatibility with PHP 7. Once this project stops supporting PHP 7 you could replace the `$jsonSerialize->addAttribute('ReturnTypeWillChange');` with `$jsonSerialize->setReturnType('mixed');`.
